### PR TITLE
RRTB-14: Update CDK bootstrap command to skip ECR creation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -76,7 +76,7 @@ jobs:
         run: mvn clean package -DskipTests
 
       - name: CDK Bootstrap
-        run: cdk bootstrap aws://${{ secrets.AWS_ACCOUNT_ID }}/us-east-1 --no-bootstrap-customer-key --cloudformation-execution-policies arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:policy/AWSCloudFormationFullAccess
+        run: cdk bootstrap aws://${{ secrets.AWS_ACCOUNT_ID }}/us-east-1 --no-bootstrap-customer-key --cloudformation-execution-policies arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:policy/AWSCloudFormationFullAccess --no-execute --toolkit-stack-name CDKToolkit
 
       - name: Deploy CDK app
         run: cdk deploy --all --require-approval never


### PR DESCRIPTION
Added `--no-execute` and `--toolkit-stack-name` parameters to `cdk bootstrap` command