### PR TITLE
fix: update artifact name in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: rrtb-artifact
-          path: rrtb-artifact
+          name: build-artifacts
+          path: .
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 

--- a/README.md
+++ b/README.md
@@ -158,3 +158,4 @@ cd ..
     ```
 # Test change
 # Trigger CI
+# Trigger CI

--- a/README.md
+++ b/README.md
@@ -157,3 +157,4 @@ cd ..
     --policy-arn arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):policy/github-actions-ssm-policy
     ```
 # Test change
+# Trigger CI


### PR DESCRIPTION
Updates the CD workflow to use the correct artifact name (build-artifacts) from CI workflow.