### PR TITLE
fix: remove npm caching from CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
       - name: Install CDK Dependencies
         run: |
           cd rrtb_infra
@@ -66,7 +65,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
       - name: Install CDK Dependencies
         run: |
           cd rrtb_infra
@@ -98,7 +96,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
       - name: Install CDK Dependencies
         run: |
           cd rrtb_infra


### PR DESCRIPTION
Removes npm caching configuration from CD workflow to resolve dependency issues.