### PR TITLE
fix: update DynamoDB permissions for input Lambda function

### DIFF
--- a/rrtb_infra/src/main/java/com/nb/AppStack.java
+++ b/rrtb_infra/src/main/java/com/nb/AppStack.java
@@ -204,11 +204,7 @@ public class AppStack extends Stack {
                         schoolTable.getTableArn(),
                         schoolTable.getTableArn() + "/index/*"))
                 .build();
-        rrtbInputLambda.getRole().attachInlinePolicy(
-            software.amazon.awscdk.services.iam.Policy.Builder.create(this, "RrtbInputLambdaDynamoDBPolicy")
-                .statements(List.of(dynamoDbPolicy))
-                .build()
-        );
+        rrtbInputLambda.addToRolePolicy(dynamoDbPolicy);
 
         final FunctionUrl rrtbInputUrl = rrtbInputLambda.addFunctionUrl(FunctionUrlOptions.builder()
                 .authType(FunctionUrlAuthType.NONE)


### PR DESCRIPTION
- Changes how DynamoDB permissions are attached to the Lambda role\n- Uses addToRolePolicy() instead of attachInlinePolicy()\n- Ensures all necessary DynamoDB actions are allowed\n- Includes permissions for all required tables and their indexes