### PR TITLE
Fix School service primary key

### DIFF
--- a/rrtb_input_tbot/src/main/java/com/nb/SchoolServiceImpl.java
+++ b/rrtb_input_tbot/src/main/java/com/nb/SchoolServiceImpl.java
@@ -22,7 +22,7 @@ import com.nb.service.SchoolService;
 @Singleton
 public class SchoolServiceImpl implements SchoolService {
     // Table attribute constants
-    public static final String SCHOOL_ID = "schoolId";
+    public static final String SCHOOL_ID = "id";
     public static final String SCHOOL_NAME = "schoolName";
     public static final String DESCRIPTION = "description";
     public static final String LOCATION = "location";
@@ -61,7 +61,7 @@ public class SchoolServiceImpl implements SchoolService {
         String telegramGroup = params.get(TELEGRAM_GROUP);
         
         Map<String, String> schoolData = new HashMap<>();
-        schoolData.put("schoolId", schoolId);
+        schoolData.put(SCHOOL_ID, schoolId);
         schoolData.put(SCHOOL_NAME, schoolName);
         
         if (description != null && !description.isEmpty()) {

--- a/rrtb_input_tbot/src/test/java/com/nb/AbstractTest.java
+++ b/rrtb_input_tbot/src/test/java/com/nb/AbstractTest.java
@@ -86,10 +86,10 @@ public abstract class AbstractTest implements TestPropertyProvider {
         CreateTableRequest schoolTableRequest = CreateTableRequest.builder()
                 .tableName(SCHOOL_TABLE_NAME)
                 .keySchema(
-                    KeySchemaElement.builder().attributeName("schoolId").keyType(KeyType.HASH).build()
+                    KeySchemaElement.builder().attributeName("id").keyType(KeyType.HASH).build()
                 )
                 .attributeDefinitions(
-                    AttributeDefinition.builder().attributeName("schoolId").attributeType(ScalarAttributeType.S).build()
+                    AttributeDefinition.builder().attributeName("id").attributeType(ScalarAttributeType.S).build()
                 )
                 .provisionedThroughput(ProvisionedThroughput.builder()
                     .readCapacityUnits(5L)

--- a/rrtb_input_tbot/src/test/java/com/nb/SchoolServiceTest.java
+++ b/rrtb_input_tbot/src/test/java/com/nb/SchoolServiceTest.java
@@ -33,7 +33,7 @@ class SchoolServiceTest extends AbstractTest {
         ScanResponse response = dynamoDbClient.scan(scanRequest);
         response.items().forEach(item -> {
             Map<String, AttributeValue> key = new HashMap<>();
-            key.put("schoolId", item.get("schoolId"));
+            key.put("id", item.get("id"));
             
             DeleteItemRequest deleteRequest = DeleteItemRequest.builder()
                     .tableName(SCHOOL_TABLE_NAME)
@@ -66,7 +66,7 @@ class SchoolServiceTest extends AbstractTest {
         assertTrue(result.isPresent());
         
         Map<String, String> school = result.get();
-        assertEquals(schoolId, school.get("schoolId"));
+        assertEquals(schoolId, school.get("id"));
         assertEquals("Test School From Lines", school.get("schoolName"));
         assertEquals("Test Description From Lines", school.get("description"));
         assertEquals("Test Location From Lines", school.get("location"));


### PR DESCRIPTION
- Fixed the primary key attribute name in SchoolServiceImpl from 'schoolId' to 'id' to match the DynamoDB table schema defined in infrastructure\n- Resolves the error: 'One or more parameter values were invalid: Missing the key id in the item'